### PR TITLE
refactor: morphing-dialog clean-up function add

### DIFF
--- a/apps/web/src/components/fancy/morphing-dialog.tsx
+++ b/apps/web/src/components/fancy/morphing-dialog.tsx
@@ -194,7 +194,9 @@ function MorphingDialogContent({
     }
 
     return () => {
-      document.body.classList.remove("overflow-hidden");
+      if (isOpen) {
+        document.body.classList.remove("overflow-hidden");
+      }
     };
   }, [isOpen, triggerRef]);
 

--- a/apps/web/src/components/fancy/morphing-dialog.tsx
+++ b/apps/web/src/components/fancy/morphing-dialog.tsx
@@ -192,6 +192,10 @@ function MorphingDialogContent({
       document.body.classList.remove("overflow-hidden");
       triggerRef.current?.focus();
     }
+
+    return () => {
+      document.body.classList.remove("overflow-hidden");
+    };
   }, [isOpen, triggerRef]);
 
   useClickOutside(containerRef, () => {


### PR DESCRIPTION
Hello : )

I’m currently developing based on your repository by forking it.
First of all, thank you for creating such an awesome portfolio!

There are some cases where a dialog is open and routing occurs without closing it.
I believe it would be good to explicitly add a clean-up function for those situations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of page scroll locking when the dialog is closed, ensuring the page can always be scrolled after the dialog is unmounted or closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->