### PR TITLE
fix: mobile menu opens unexpectedly on external clicks

### DIFF
--- a/apps/web/src/components/sections/header/compact/header.tsx
+++ b/apps/web/src/components/sections/header/compact/header.tsx
@@ -144,6 +144,10 @@ export default function Header() {
         initial="closed"
         animate={isOpen ? "open" : "closed"}
         className="bg-transparent md:hidden"
+        style={{
+          pointerEvents: isOpen ? "auto" : "none",
+          display: isOpen ? "block" : "none",
+        }}
       >
         <div className="flex flex-col gap-4 p-4">
           {links.map(({ title, href }, index) => (

--- a/apps/web/src/components/sections/header/compact/header.tsx
+++ b/apps/web/src/components/sections/header/compact/header.tsx
@@ -146,7 +146,6 @@ export default function Header() {
         className="bg-transparent md:hidden"
         style={{
           pointerEvents: isOpen ? "auto" : "none",
-          display: isOpen ? "block" : "none",
         }}
       >
         <div className="flex flex-col gap-4 p-4">

--- a/apps/web/src/components/sections/header/compact/header.tsx
+++ b/apps/web/src/components/sections/header/compact/header.tsx
@@ -146,6 +146,7 @@ export default function Header() {
         className="bg-transparent md:hidden"
         style={{
           pointerEvents: isOpen ? "auto" : "none",
+          visibility: isOpen ? "visible" : "hidden",
         }}
       >
         <div className="flex flex-col gap-4 p-4">


### PR DESCRIPTION
Hello : )

I've been using your project nicely after forking it, and I found a bug that I've fixed~!



## 🐛 Fix: Mobile menu opens unexpectedly on external clicks

### Problem
The mobile menu in the compact header was opening when users clicked outside of it, even when the menu was in a closed state. This was caused by the menu still being interactive even when visually closed.

### Solution
- Added `style` prop to `motion.div` with conditional `pointerEvents` and `display`
- When `isOpen` is false: `pointerEvents: "none"` and `display: "none"`
- When `isOpen` is true: `pointerEvents: "auto"` and `display: "block"`
- This ensures the menu is completely non-interactive when closed

https://github.com/user-attachments/assets/2a675730-71c0-4d2f-b902-ac178d6c2cf1




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile menu behavior to ensure it is only visible and interactive when open, and fully hidden and non-interactive when closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->